### PR TITLE
run: move run.js to root

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -1,2 +1,0 @@
-var app = require('../apex-doc-node.js');
-app.run();

--- a/run.js
+++ b/run.js
@@ -1,0 +1,8 @@
+/**
+ * run.js allows for local execution of apex-doc-node. The main
+ * apex-doc-node file exports the config and engine to be used
+ * in grunt or other task runners.
+ */
+
+var app = require('./apex-doc-node.js');
+app.run();


### PR DESCRIPTION
Move the run.js file to the root directory to line up with the “node run” command listed in the README.

Fixes #9 